### PR TITLE
SP-133: Set all pay at table config to false on instantiation

### DIFF
--- a/src/SpiPayAtTable.js
+++ b/src/SpiPayAtTable.js
@@ -8,19 +8,7 @@ export class SpiPayAtTable
         this._spi = spi;
         this._log = console;
 
-        this.Config = Object.assign(new PayAtTableConfig(), {
-            PayAtTabledEnabled: true,
-            OperatorIdEnabled: true,
-            AllowedOperatorIds: [],
-            EqualSplitEnabled: true,
-            SplitByAmountEnabled: true,
-            SummaryReportEnabled: true,
-            TippingEnabled: true,
-            LabelOperatorId: "Operator ID",
-            LabelPayButton: "Pay at Table",
-            LabelTableId: "Table Number",
-            TableRetrievalEnabled: true
-        });
+        this.Config = new PayAtTableConfig();
     }
 
     // <summary>

--- a/tests/SpiPayAtTable.spec.js
+++ b/tests/SpiPayAtTable.spec.js
@@ -13,6 +13,7 @@ describe('SpiPayAtTable', function() {
 
         expect(payAtTable._spi).toBeDefined();
         expect(payAtTable.Config).toBeDefined();
+        expect(payAtTable.Config.TableRetrievalEnabled).toBeFalsy();
     });
   
     it('should push pay at table config', function() 


### PR DESCRIPTION
I've stopped the PayAtTableConfig turning everything on when SpiPayAtTable is instantiated and added a test to ensure that the main target, TableRetrievalEnabled, is turned-off by default.