### PR TITLE
(SP-198, SP-220, SP-223): Auto address resolution timeouts, retries and logging TX past no return

### DIFF
--- a/src/Purchase.js
+++ b/src/Purchase.js
@@ -223,6 +223,11 @@ export class CancelTransactionResponse
         return this._m.Data.error_detail;
     }
 
+    WasTxnPastPointOfNoReturn()
+    {
+        return this._m.GetError().startsWith("TXN_PAST_POINT_OF_NO_RETURN");
+    }
+
     GetResponseValueWithAttribute(attribute)
     {
         return this._m.Data[attribute];

--- a/src/Service/DeviceService.js
+++ b/src/Service/DeviceService.js
@@ -57,16 +57,20 @@ export class DeviceAddressService
     // RetrieveService(serialNumber, apiKey = 'spi-sample-pos1', acquirerCode, useSecureWebSockets, isTestMode)
     async RetrieveService(serialNumber, apiKey = 'spi-sample-pos1', acquirerCode, isSecureConnection, isTestMode)    
     {
+        const CONNECTION_TIMEOUT = 3000;
         var path = isSecureConnection ? 'fqdn' : 'ip';
         var deviceAddressUri = isTestMode ? `https://device-address-api-sb.${acquirerCode}.msp.assemblypayments.com/v1/${serialNumber}/${path}` : `https://device-address-api.${acquirerCode}.msp.assemblypayments.com/v1/${serialNumber}/${path}`;
 
-        var response = await fetch(deviceAddressUri, {
-            method: 'GET',
-            headers: {
-                "ASM-MSP-DEVICE-ADDRESS-API-KEY": apiKey
-            }
-        });
-
-        return response;
+        return Promise.race([
+            fetch(deviceAddressUri, {
+              method: 'GET',
+              headers: {
+                'ASM-MSP-DEVICE-ADDRESS-API-KEY': apiKey,
+              },
+            }),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('Timeout while trying to retrieve IP address')), CONNECTION_TIMEOUT)
+            ),
+          ]);
     }
 }

--- a/src/Spi.js
+++ b/src/Spi.js
@@ -1246,15 +1246,18 @@ class Spi {
     //When the transaction cancel response is returned.
     _handleCancelTransactionResponse(m)
     {
-        var incomingPosRefId = m.Data.pos_ref_id;
-        if (this.CurrentFlow != SpiFlow.Transaction || this.CurrentTxFlowState.Finished || !this.CurrentTxFlowState.PosRefId == incomingPosRefId)
-        {
-            this._log.info(`Received Cancel Required but I was not waiting for one. Incoming Pos Ref ID: ${incomingPosRefId}`);
-            return;
-        }
+        const incomingPosRefId = m.Data.pos_ref_id;
+        const txState = this.CurrentTxFlowState;
 
-        var txState = this.CurrentTxFlowState;
-        var cancelResponse = new CancelTransactionResponse(m);
+        if (this.CurrentFlow != SpiFlow.Transaction || this.txState.Finished || !this.txState.PosRefId == incomingPosRefId)
+        {
+            const cancelResponse = new CancelTransactionResponse(m);
+
+            if (!cancelResponse.WasTxnPastPointOfNoReturn()) {
+                this._log.info(`Received Cancel Required but I was not waiting for one. Incoming Pos Ref ID: ${incomingPosRefId}`);
+                return;
+            }
+        }
 
         if (cancelResponse.Success) return;
 

--- a/src/Spi.js
+++ b/src/Spi.js
@@ -1785,10 +1785,12 @@ class Spi {
         }
         catch (err) 
         {
+            this.CurrentDeviceStatus = this.CurrentDeviceStatus || new DeviceAddressStatus(isSecureConnection);
             this.CurrentDeviceStatus.DeviceAddressResponseCode = DeviceAddressResponseCode.DEVICE_SERVICE_ERROR;
             this.CurrentDeviceStatus.ResponseStatusDescription = err;
             this.CurrentDeviceStatus.ResponseMessage = err;
 
+            this._log.warn(err.message);
             document.dispatchEvent(new CustomEvent('DeviceAddressChanged', {detail: this.CurrentDeviceStatus}));
             return; 
         }

--- a/src/Spi.js
+++ b/src/Spi.js
@@ -77,7 +77,7 @@ class Spi {
         this._maxWaitForCancelTx = 10000;
         this._sleepBeforeReconnectMs = 3000;
         this._missedPongsToDisconnect = 2;
-        this._retriesBeforeResolvingDeviceAddress = 5;
+        this._retriesBeforeResolvingDeviceAddress = 3;
 
         this.CurrentFlow                = null;
         this.CurrentPairingFlowState    = null;

--- a/tests/utils/SpiClientUtils.js
+++ b/tests/utils/SpiClientUtils.js
@@ -1,0 +1,12 @@
+import { Secrets } from '../../src/Secrets';
+
+export class SpiClientUtils {
+  static SetTestSecrets(encKey = '', hmacKey = '') {
+    if (!encKey || !hmacKey) {
+      encKey = '81CF9E6A14CDAF244A30B298D4CECB505C730CE352C6AF6E1DE61B3232E24D3F';
+      hmacKey = 'D35060723C9EECDB8AEA019581381CB08F64469FC61A5A04FE553EBDB5CD55B9';
+    }
+
+    return new Secrets(encKey, hmacKey);
+  }
+}


### PR DESCRIPTION
I've:

- Added a timeout for the device address auto resolution during the http request so that it is consistent with the other libraries (SP-223)
- Fixed the misidentification of errors resulting from trying to cancel transactions past the point of no return (SP-198)
- Updated the auto address resolution retry limit from 5 to 3 (SP-220)
