### PR TITLE
SP-62, SP-213 & SP-217: Null table data, null terminal event handlers and looping pairing attempts

### DIFF
--- a/src/Spi.js
+++ b/src/Spi.js
@@ -1361,17 +1361,17 @@ class Spi {
 
     _handlePrintingResponse(m)
     {
-        this.PrintingResponse(m);
+        if (typeof this.PrintingResponse === 'function') this.PrintingResponse(m);
     }
 
     _handleTerminalStatusResponse(m)
     {
-        this.TerminalStatusResponse(m);
+        if (typeof this.TerminalStatusResponse === 'function') this.TerminalStatusResponse(m);
     }
 
     _handleBatteryLevelChanged(m)
     {
-        this.BatteryLevelChanged(m);
+        if (typeof this.BatteryLevelChanged === 'function') this.BatteryLevelChanged(m);
     }
 
     // endregion

--- a/src/SpiPayAtTable.js
+++ b/src/SpiPayAtTable.js
@@ -125,12 +125,15 @@ export class SpiPayAtTable
 
     _handleGetOpenTablesRequest(m)
     {
-        var operatorId = m.Data["operator_id"];
+        const operatorId = m.Data["operator_id"];
 
         // Ask POS for Bill Details for this tableId, inluding encoded PaymentData
-        var openTablesResponse = this.GetOpenTables(operatorId); // JSON or string?
-        if (openTablesResponse.TableData.length <= 0)
+        const openTablesResponse = typeof this.GetOpenTables === 'function'
+            ? this.GetOpenTables(operatorId)
+            : null;
+        if (!openTablesResponse || !openTablesResponse.TableData || !openTablesResponse.TableData.length)
         {
+            openTablesResponse = new GetOpenTablesResponse();
             this._log.info("There is no open table.");
         }
 

--- a/tests/SpiPayAtTable.spec.js
+++ b/tests/SpiPayAtTable.spec.js
@@ -1,6 +1,6 @@
 import {Spi} from '../src/Spi';
 import {SpiPayAtTable} from '../src/SpiPayAtTable';
-import {BillStatusResponse, BillRetrievalResult} from '../src/PayAtTable';
+import {BillStatusResponse, BillRetrievalResult, GetOpenTablesResponse, OpenTablesEntry} from '../src/PayAtTable';
 import {Message} from '../src/Messages';
 
 describe('SpiPayAtTable', function() {
@@ -25,6 +25,42 @@ describe('SpiPayAtTable', function() {
         payAtTable.PushPayAtTableConfig();
 
         expect(spi._send).toHaveBeenCalledWith(jasmine.objectContaining({ EventName: 'set_table_config' }));
+    });
+
+    it('should open a table and correctly return a response with the open table', () =>
+    {
+        // arrange
+        const openTablesEntries = [];
+        const openTablesEntry = Object.assign(new OpenTablesEntry(), {
+            TableId: '1',
+            Label: '1',
+            BillOutstandingAmount: 2000,
+        });
+        openTablesEntries.push(openTablesEntry);
+
+        // act
+        const getOpenTablesResponse = Object.assign(new GetOpenTablesResponse(), {
+            TableData: JSON.stringify(openTablesEntries),
+        });
+        const openTablesResponse = getOpenTablesResponse.GetOpenTables();
+
+        // assert
+        expect(openTablesResponse.length).toBe(openTablesEntries.length);
+    });
+    
+    it('should return an empty array when the open table data is null', () =>
+    {
+        // arrange
+        const getOpenTablesResponse = Object.assign(new GetOpenTablesResponse(), {
+            TableData: null,
+        });
+
+        // act
+        const openTablesResponse = getOpenTablesResponse.GetOpenTables();
+
+        // assert
+        expect(openTablesResponse.length).toBe(0);
+        expect(getOpenTablesResponse.TableData).toBeNull();
     });
 
     it('should handle bill status request', function() 


### PR DESCRIPTION
I've:

- fix(SP-213): Allow passing table data that can be set to null
- fix(SP-62): Guard against overriding handlers with values that are not functions
- feat(SP-217): When pairing is interrupted loop pairing attempts